### PR TITLE
Serve images in modern formats

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -55,7 +55,7 @@ group :jekyll_plugins do
 
   gem 'jekyll-subresource-integrity-hook', git: "https://github.com/Garanas/jekyll-subresource-integrity-hook"
 
-  gem 'jekyll-transcode-image-filters'
+  gem 'jekyll-transcode-image-filters', git: "https://github.com/Garanas/jekyll-transcode-image-filters"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/src/Gemfile
+++ b/src/Gemfile
@@ -54,6 +54,8 @@ group :jekyll_plugins do
   # - https://github.com/Garanas/jekyll-sub-resource-integrity-hook
 
   gem 'jekyll-subresource-integrity-hook', git: "https://github.com/Garanas/jekyll-subresource-integrity-hook"
+
+  gem 'jekyll-transcode-image-filters'
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -7,6 +7,14 @@ GIT
       nokogiri (~> 1.18.1)
 
 GIT
+  remote: https://github.com/Garanas/jekyll-transcode-image-filters
+  revision: 2576fe8c8164ed96fbce90ddb2f10d61117925dd
+  specs:
+    jekyll-transcode-image-filters (0.0.1)
+      jekyll (> 3.3, < 5.0)
+      mini_magick (~> 4.8)
+
+GIT
   remote: https://github.com/MichaelCurrin/jekyll-resize
   revision: 917a7572d0318e40f4a420d5b2ce9e8dbe16776c
   specs:
@@ -230,9 +238,6 @@ GEM
       jekyll-seo-tag (~> 2.0)
     jekyll-titles-from-headings (0.5.3)
       jekyll (>= 3.3, < 5.0)
-    jekyll-transcode-image-filters (0.0.1)
-      jekyll (> 3.3, < 5.0)
-      mini_magick (~> 4.8)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     jemoji (0.13.0)
@@ -314,7 +319,7 @@ DEPENDENCIES
   jekyll-resize!
   jekyll-seo-tag (~> 2.1)
   jekyll-subresource-integrity-hook!
-  jekyll-transcode-image-filters
+  jekyll-transcode-image-filters!
   tzinfo (>= 1, < 3)
   tzinfo-data
   wdm (~> 0.1)

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -230,6 +230,9 @@ GEM
       jekyll-seo-tag (~> 2.0)
     jekyll-titles-from-headings (0.5.3)
       jekyll (>= 3.3, < 5.0)
+    jekyll-transcode-image-filters (0.0.1)
+      jekyll (> 3.3, < 5.0)
+      mini_magick (~> 4.8)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     jemoji (0.13.0)
@@ -311,6 +314,7 @@ DEPENDENCIES
   jekyll-resize!
   jekyll-seo-tag (~> 2.1)
   jekyll-subresource-integrity-hook!
+  jekyll-transcode-image-filters
   tzinfo (>= 1, < 3)
   tzinfo-data
   wdm (~> 0.1)

--- a/src/_includes/components/banner.html
+++ b/src/_includes/components/banner.html
@@ -2,6 +2,13 @@
   Input parameters:
   - url: the src attribute of the image
   - alt: the alt attribute of the image
+
+  Related documentation:
+  - https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types
+  - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture
+  - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source
+  - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
+
 {% endcomment %}
 
 {% assign assetsFolder = 'assets/thumbnails-wide/' %}
@@ -10,15 +17,35 @@
   {% assign imagePath = assetsFolder | append: include.url %}
   <source
     media="(max-width: 960px)"
-    srcset="{{ imagePath | resize: "240x135>" }}"
+    srcset="{{ imagePath | resize: "240x135>" | webp }}"
+    type="image/webp"
   >
   <source
     media="(max-width: 1920px)"
-    srcset="{{ imagePath | resize: "480x270>" }}"
+    srcset="{{ imagePath | resize: "480x270>" | webp }}"
+    type="image/webp"
   >
   <source
     media="(max-width: 2560px)"
-    srcset="{{ imagePath | resize: "960x540>" }}"
+    srcset="{{ imagePath | resize: "960x540>" | webp }}"
+    type="image/webp"
   >
+
+  <source
+    media="(max-width: 960px)"
+    srcset="{{ imagePath | resize: "240x135>" | jpg }}"
+    type="image/jpeg"
+  >
+  <source
+    media="(max-width: 1920px)"
+    srcset="{{ imagePath | resize: "480x270>" | jpg }}"
+    type="image/jpeg"
+  >
+  <source
+    media="(max-width: 2560px)"
+    srcset="{{ imagePath | resize: "960x540>" | jpg}}"
+    type="image/jpeg"
+  >
+
   <img class="banner-image" src="{{ imagePath | relative_url }}" alt="{{include.alt}}">
 </picture>

--- a/src/_includes/components/banner.html
+++ b/src/_includes/components/banner.html
@@ -1,4 +1,5 @@
 {% comment %}
+
   Input parameters:
   - url: the src attribute of the image
   - alt: the alt attribute of the image
@@ -15,37 +16,59 @@
 
 <picture>
   {% assign imagePath = assetsFolder | append: include.url %}
+  
+  {% comment %} AVIF {% endcomment %}
+
   <source
     media="(max-width: 960px)"
-    srcset="{{ imagePath | resize: "240x135>" | webp }}"
+    srcset="{{ imagePath | avif: "240x135"  }}"
+    type="image/avif"
+  >
+  <source
+    media="(max-width: 1920px)"
+    srcset="{{ imagePath | avif: "480x270"  }}"
+    type="image/avif"
+  >
+  <source
+    media="(max-width: 2560px)"
+    srcset="{{ imagePath | avif: "960x540" }}"
+    type="image/avif"
+  >
+    {% comment %} WEBP {% endcomment %}
+
+  <source
+    media="(max-width: 960px)"
+    srcset="{{ imagePath | webp: "240x135"   }}"
     type="image/webp"
   >
   <source
     media="(max-width: 1920px)"
-    srcset="{{ imagePath | resize: "480x270>" | webp }}"
+    srcset="{{ imagePath | webp: "480x270"  }}"
     type="image/webp"
   >
   <source
     media="(max-width: 2560px)"
-    srcset="{{ imagePath | resize: "960x540>" | webp }}"
+    srcset="{{ imagePath | webp: "960x540" }}"
     type="image/webp"
   >
 
-  <source
+    {% comment %} JPG {% endcomment %}
+
+    <source
     media="(max-width: 960px)"
-    srcset="{{ imagePath | resize: "240x135>" | jpg }}"
+    srcset="{{ imagePath | jpg: "240x135"  }}"
     type="image/jpeg"
   >
   <source
     media="(max-width: 1920px)"
-    srcset="{{ imagePath | resize: "480x270>" | jpg }}"
+    srcset="{{ imagePath | jpg: "480x270"  }}"
     type="image/jpeg"
   >
   <source
     media="(max-width: 2560px)"
-    srcset="{{ imagePath | resize: "960x540>" | jpg}}"
+    srcset="{{ imagePath | jpg: "960x540" }}"
     type="image/jpeg"
   >
 
-  <img class="banner-image" src="{{ imagePath | relative_url }}" alt="{{include.alt}}">
+  <img class="banner-image" src="{{ imagePath | relative_url }}" alt="{{include.alt}}" loading="lazy">
 </picture>

--- a/src/_includes/components/thumbnail.html
+++ b/src/_includes/components/thumbnail.html
@@ -1,4 +1,5 @@
 {% comment %}
+
   Input parameters:
   - url: the src attribute of the image
   - alt: the alt attribute of the image
@@ -8,43 +9,66 @@
   - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture
   - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source
   - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
+
 {% endcomment %}
 
 {% assign assetsFolder = 'assets/thumbnails-wide/' %}
 
 <picture>
   {% assign imagePath = assetsFolder | append: include.url %}
+  
+  {% comment %} AVIF {% endcomment %}
+
   <source
+  media="(max-width: 960px)"
+  srcset="{{ imagePath | avif: "240x135"  }}"
+  type="image/avif"
+>
+<source
+  media="(max-width: 1920px)"
+  srcset="{{ imagePath | avif: "480x270"  }}"
+  type="image/avif"
+>
+<source
+  media="(max-width: 2560px)"
+  srcset="{{ imagePath | avif: "960x540" }}"
+  type="image/avif"
+>
+    {% comment %} WEBP {% endcomment %}
+
+    <source
     media="(max-width: 960px)"
-    srcset="{{ imagePath | resize: "240x135>" | webp }}"
+    srcset="{{ imagePath | webp: "240x135" }}"
     type="image/webp"
   >
   <source
     media="(max-width: 1920px)"
-    srcset="{{ imagePath | resize: "480x270>" | webp }}"
+    srcset="{{ imagePath | webp: "480x270" }}"
     type="image/webp"
   >
   <source
     media="(max-width: 2560px)"
-    srcset="{{ imagePath | resize: "960x540>" | webp}}"
+    srcset="{{ imagePath | webp: "960x540"}}"
     type="image/webp"
   >
 
+    {% comment %} JPG {% endcomment %}
+
   <source
     media="(max-width: 960px)"
-    srcset="{{ imagePath | resize: "240x135>" | jpg }}"
+    srcset="{{ imagePath | jpg: "240x135" }}"
     type="image/jpeg"
   >
   <source
     media="(max-width: 1920px)"
-    srcset="{{ imagePath | resize: "480x270>" | jpg }}"
+    srcset="{{ imagePath | jpg: "480x270" }}"
     type="image/jpeg"
   >
   <source
     media="(max-width: 2560px)"
-    srcset="{{ imagePath | resize: "960x540>" | jpg}}"
+    srcset="{{ imagePath | jpg: "960x540" }}"
     type="image/jpeg"
   >
 
-  <img class="thumbnail-image" src="{{ imagePath | relative_url }}" alt="{{include.alt}}">
+  <img class="thumbnail-image" src="{{ imagePath | relative_url }}" alt="{{include.alt}}" loading="lazy">
 </picture>

--- a/src/_includes/components/thumbnail.html
+++ b/src/_includes/components/thumbnail.html
@@ -2,6 +2,12 @@
   Input parameters:
   - url: the src attribute of the image
   - alt: the alt attribute of the image
+
+  Related documentation:
+  - https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types
+  - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture
+  - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source
+  - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
 {% endcomment %}
 
 {% assign assetsFolder = 'assets/thumbnails-wide/' %}
@@ -10,15 +16,35 @@
   {% assign imagePath = assetsFolder | append: include.url %}
   <source
     media="(max-width: 960px)"
-    srcset="{{ imagePath | resize: "240x135>" }}"
+    srcset="{{ imagePath | resize: "240x135>" | webp }}"
+    type="image/webp"
   >
   <source
     media="(max-width: 1920px)"
-    srcset="{{ imagePath | resize: "480x270>" }}"
+    srcset="{{ imagePath | resize: "480x270>" | webp }}"
+    type="image/webp"
   >
   <source
     media="(max-width: 2560px)"
-    srcset="{{ imagePath | resize: "960x540>" }}"
+    srcset="{{ imagePath | resize: "960x540>" | webp}}"
+    type="image/webp"
   >
+
+  <source
+    media="(max-width: 960px)"
+    srcset="{{ imagePath | resize: "240x135>" | jpg }}"
+    type="image/jpeg"
+  >
+  <source
+    media="(max-width: 1920px)"
+    srcset="{{ imagePath | resize: "480x270>" | jpg }}"
+    type="image/jpeg"
+  >
+  <source
+    media="(max-width: 2560px)"
+    srcset="{{ imagePath | resize: "960x540>" | jpg}}"
+    type="image/jpeg"
+  >
+
   <img class="thumbnail-image" src="{{ imagePath | relative_url }}" alt="{{include.alt}}">
 </picture>


### PR DESCRIPTION
Guarantees that thumbnails and banners are served as AVIF, WebP or JPG. For more information, see also:

- https://developer.chrome.com/docs/lighthouse/performance/uses-webp-images/
